### PR TITLE
Additional template clean up

### DIFF
--- a/404.markdown
+++ b/404.markdown
@@ -1,8 +1,8 @@
 ---
 permalink: /404.html
 layout: error
-errormessage: 🙅‍♀️ 404
-errorhuman: "Valkey can't find that page. Ironic." 
+errormessage: 404
+errorhuman: "Page not found" 
 ---
 
-Perhaps you mistyped the URL or we've moved something around. Sorry 'bout that.
+Perhaps you mistyped the URL or we've moved something around. Sorry about that.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet" href="{{'assets/css/styles.css' | relative_url }}">
 
 
-    <!-- Google tag (gtag.js) -->
+    <!-- Google tag (gtag.js)
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-6M0FF13NRB"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -30,7 +30,7 @@
       gtag('js', new Date());
 
       gtag('config', 'G-6M0FF13NRB');
-    </script>
+    </script> -->
 
     {{ page.head_extra }}
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,8 +16,7 @@
                 <span>Community</span>
                 <div class="submenu">
                     <a role="menuitem" href="/blog/">Blog</a>
-                    <a role="menuitem" href="/">Forum</a>
-                    <a role="menuitem" href="/slack.html">Slack</a>
+                    <a role="menuitem" href="https://github.com/orgs/valkey-io/discussions">Forum</a>
                 </div>
             </div>
         </nav>
@@ -32,26 +31,16 @@
             <nav role="navigation" aria-label="Get Involved">
                 <h4>Get Involved</h4>
                 <a role="menuitem" href="/code_of_conduct.html">Code of Conduct</a>
-                <a role="menuitem" href="/">Forum</a>
-                <a role="menuitem" href="/">GitHub</a>
-                <a role="menuitem" href="/">Slack</a>
+                <a role="menuitem" href="https://github.com/orgs/valkey-io/discussions">Forum</a>
+                <a role="menuitem" href="https://github.com/valkey-io">GitHub</a>
             </nav>
             <nav role="navigation" aria-label="Resources">
                 <h4>Resources</h4>
-                <a role="menuitem" href="/about.html">About</a>
-                <a role="menuitem" href="/maintenance_policy.html">Maintenance Policy</a>
-                <a role="menuitem" href="/faq.html">FAQ</a>
-                <a role="menuitem" href="/branding.html">Trademark and Brand Policy</a>
-                <a role="menuitem" href="/privacy.html">Privacy Policy</a>
+                <a role="menuitem" href="/about">About</a>
             </nav>
             <nav role="navigation" aria-label="Contact Us">
-                <h4>Contact Us</h4>
+                <h4>Contact</h4>
                 <a role="menuitem" href="/connect.html">Connect</a>
-                <a role="menuitem" href="/">X (formerly Twitter)</a>
-                <a role="menuitem" href="/">LinkedIn</a>
-                <a role="menuitem" href="/">YouTube</a>
-                <a role="menuitem" href="/">Meetup</a>
-                <a role="menuitem" href="/">Facebook</a>
             </nav>
         </div>
         <p>&copy; Valkey contributors, 2024. Valkey is a registered trademark of Linux Foundation.</p>

--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,5 @@
+---
+layout: simple
+primary_title: About
+title: About
+---

--- a/download/index.html
+++ b/download/index.html
@@ -1,0 +1,5 @@
+---
+layout: simple
+primary_title: Download
+title: Download
+---

--- a/index.markdown
+++ b/index.markdown
@@ -14,7 +14,7 @@ ctas:
 
 headline: "Valkey: an open source, in-memory data store"
 
-long_description: "Valkey is a community-driven, open source SOMETHING ELSE."
+long_description: ""
     
 sidebar:
     -

--- a/source.markdown
+++ b/source.markdown
@@ -1,6 +1,0 @@
----
-layout: source
-body_class: source-page
----
-
-The Valkey is open source software with an PLACEHOLDER license. We encourage you to use both to the full extent of this license. 


### PR DESCRIPTION
### Description

1. Removed various bits of template leftovers (footer links, homepage dummy text, 404 page references)
2. Commented out google analytics heading, this seems like another template left over. I assume LF will want to have their own tags in this area.
3. Added stub pages for `about` and `download` so they don't 404

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
