### PR TITLE
clean up brand, make it look like the LF announcement 

### DIFF
--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -24,15 +24,15 @@ $blue-lt-000: #EAF4F9;
 
 $white: #FFFFFF;
 
-$grey-dk-300: #002A3A; // Midnight Sky
-$grey-dk-200: #1B4859;
-$grey-dk-100: #346173;
-$grey-dk-000: #4D8399;
+$grey-dk-300: #222222;
+$grey-dk-200: #444444;
+$grey-dk-100: #666666;
+$grey-dk-000: #888888;
 
-$grey-lt-300: #D9E1E2; // San Francisco Fog
-$grey-lt-000: #F5F7F7;
+$grey-lt-300: #aaaaaa; 
+$grey-lt-000: #dddddd;
 
-$purple-000: #963CBD; // Purple Sage
+$purple-000: #963CBD; 
 $purple-100: #8736AA;
 $purple-200: #692A84;
 $purple-300: #4B1E5F;
@@ -52,7 +52,10 @@ $red-100: #DD4A69;
 $red-200: #AC3952;
 $red-300: #7B293B;
 
-$body-background-color: #d7f1fc;
+
+$lf-dark-blue: #123678;
+$lf-light-blue: #3393FF;  
+$body-background-color: #fff;
 $sidebar-color: $grey-lt-000;
 $code-background-color: $grey-lt-000;
 
@@ -69,7 +72,7 @@ $logo_width: 250px;
 $attention-light: #4fb3e3;
 $attention: #3bf; //formerly $green-medium, open sky
 $attention-dark: #0082b3; //formerly $green-medium-dark, open sky, tent 1
-$core:  #0053b8; //pacific blue
+$core:  #123678; //pacific blue
 
 $warning-light: #ffc460; //golden poppy, tint 2
 $warning: #ffb81c; //golden poppy

--- a/_sass/_valkey.scss
+++ b/_sass/_valkey.scss
@@ -44,15 +44,15 @@ body {
   align-items: stretch;
   align-content: stretch;
   font-size: 1.8rem;
-  @include serif;
+  @include sans-serif;
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  @include condensed-sans-serif;
-  font-weight: 700;
+  @include sans-serif;
+  font-weight: 400;
 }
 
 h1 {
@@ -103,27 +103,26 @@ p {
 }
 
 .header {
-  color: #215d7a;
+  border-bottom: 1px solid $grey-lt-000;
+  color: $lf-dark-blue;
   padding: 10px 0;
 
   .width-limiter {
     flex-flow: row nowrap;
     justify-content: space-between;
-    align-items: center;
+    align-items: baseline;
   }
 
   .logo {
     display: block;
     height: 6rem;
-    padding-left: 7rem;
-    background: url('../img/valkey.png') 0 center / 6rem auto no-repeat;
-    @include condensed-sans-serif;
-    font-weight: 800;
+    @include sans-serif;
+    font-weight: 400;
     font-size: 6rem;
     line-height: 5.75rem;
     color: inherit;
     text-decoration: none;
-    text-transform: uppercase;
+    letter-spacing: -0.2rem;
   }
 
   nav {
@@ -131,7 +130,7 @@ p {
     flex-flow: row nowrap;
     @include sans-serif;
     font-size: 1.5rem;
-    font-weight: 700;
+    font-weight: 400;
 
     a {
       white-space: nowrap;
@@ -195,8 +194,8 @@ p {
 }
 
 .footer {
-  background: linear-gradient(to bottom, #41799f, #07293a 80%);
-  color: #fff;
+  border-top: 1px solid $grey-dk-100;
+  background-color: $grey-lt-300;
   @include sans-serif;
   font-size: 1.4rem;
 
@@ -212,18 +211,15 @@ p {
     font-weight: 600;
 
     h4 {
-      font-weight: 600;
+      font-weight: 400;
       @include sans-serif;
-      text-transform: uppercase;
       font-size: 1.5rem;
-      letter-spacing: .45rem;
     }
 
     a {
       display: list-item;
       list-style: none;
       white-space: nowrap;
-      color: #fff;
       margin-bottom: 1em;
 
       &:hover {
@@ -237,7 +233,7 @@ p {
   max-width: var(--max-width);
   display: flex;
   flex-flow: column nowrap;
-  padding: 10px 20px;
+  padding: 10px 20px 0 20px;
   align-content: stretch;
   height: 100%;
   margin: 0 auto;
@@ -249,7 +245,7 @@ p {
   margin: 0 auto;
   padding: 2rem;
   color: $body-text-color;
-  border-bottom: 10px solid $body-heading-color;
+  border-bottom: 1px dotted $lf-light-blue;
   font-weight: 300;
   font-size: 4rem;
   @include sans-serif;


### PR DESCRIPTION
### Description

Removes remaining blues and serif fonts, makes the site more neutral
 
![Screenshot 2024-04-08 at 3 34 04 PM](https://github.com/valkey-io/valkey-website/assets/1152927/209a4288-ade9-4ac7-8f3a-62137c377885)

### Issues Resolved

#14

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
